### PR TITLE
Add MIT LICENSE and update docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) 2024 Gabriel Goés
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ chmod +x ./install.sh
 Gabriel Góes
 
 ## Licença
-Este projeto é licenciado sob a GPL - veja o arquivo 'LICENÇA' para detalhes.
+Este projeto é licenciado sob a MIT License - veja o arquivo 'LICENSE' para detalhes.
 
 ## Contato
 Para mais informações, entre em contato pelo correio eletrônico gabrielgoes@usp.br


### PR DESCRIPTION
## Summary
- add MIT license file
- reference MIT License in README
- keep same license info in `pyproject.toml`

## Testing
- `python3 -m venv /tmp/venv`
- `source /tmp/venv/bin/activate && pip install pytest`
- `pytest` *(fails: ModuleNotFoundError: No module named 'qgis')*

------
https://chatgpt.com/codex/tasks/task_e_686c4c1be0b8832da9b5ea00636acbbe