### PR TITLE
Use DB_URL env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ chmod +x ./install.sh
 <span style="font-size:smaller;">_Este processo deve ser facilitando no futuro utilizando [docker]()_</span>
 <span style="font-size:smaller;">_Ou refatorando a interface de TKinter para PyQT e adicioanndo ao QGIS como um plugin_</span>
 
+## Variáveis de Ambiente
+Defina a variável `DB_URL` com a string de conexão para o banco PostGIS.
+Caso ela não seja fornecida, será utilizado o padrão
+`postgresql+psycopg2://postgres:postgres@localhost:5432/geodatabase`.
+
+```bash
+export DB_URL="postgresql+psycopg2://usuario:senha@localhost:5432/geodatabase"
+```
 
 ## Uso
 ```

--- a/fonte/mapgeo/databaseengine.py
+++ b/fonte/mapgeo/databaseengine.py
@@ -11,10 +11,14 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm import declarative_base
 from sqlalchemy import Column, Integer, String
 from geoalchemy2 import Geometry
+import os
 
 
 # ------------------------------ PARAMETR ------------------------------------
-url = 'postgresql+psycopg2://postgres:postgres@localhost:5432/geodatabase'
+url = os.getenv(
+    "DB_URL",
+    "postgresql+psycopg2://postgres:postgres@localhost:5432/geodatabase",
+)
 Base = declarative_base()
 
 

--- a/fonte/mapgeo/nucleo/databaseengine.py
+++ b/fonte/mapgeo/nucleo/databaseengine.py
@@ -11,10 +11,14 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm import declarative_base
 from sqlalchemy import Column, Integer, String
 from geoalchemy2 import Geometry
+import os
 
 
 # ------------------------------ PARAMETR ------------------------------------
-url = 'postgresql+psycopg2://postgres:postgres@localhost:5432/geodatabase'
+url = os.getenv(
+    "DB_URL",
+    "postgresql+psycopg2://postgres:postgres@localhost:5432/geodatabase",
+)
 Base = declarative_base()
 
 

--- a/fonte/mapgeo/nucleo/utils.py
+++ b/fonte/mapgeo/nucleo/utils.py
@@ -17,7 +17,10 @@ delimt = '------------------------------------------------------\n'
 
 
 # configura PostgreSQL para conexão
-gdb_url = 'postgresql+psycopg2://postgres:postgres@localhost:5432/geodatabase'
+gdb_url = os.getenv(
+    "DB_URL",
+    "postgresql+psycopg2://postgres:postgres@localhost:5432/geodatabase",
+)
 
 
 def set_db(path=''):


### PR DESCRIPTION
## Summary
- read DB_URL environment variable in DatabaseEngine
- read DB_URL environment variable in utils
- document DB_URL in README

## Testing
- `python3 -m py_compile fonte/mapgeo/databaseengine.py fonte/mapgeo/nucleo/databaseengine.py fonte/mapgeo/nucleo/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_686c4c21b778832db28dc46de5b40bd2