### PR TITLE
Fix plugin menu API calls

### DIFF
--- a/fonte/mapgeo/mapgeo.py
+++ b/fonte/mapgeo/mapgeo.py
@@ -51,7 +51,7 @@ class mapgeo:
             self.iface.addToolBarIcon(action)
 
         if add_to_menu:
-            self.iface.addPluginToDatabaseMenu(self.menu, action)
+            self.iface.addPluginToMenu(self.menu, action)
 
         self.actions.append(action)
         return action
@@ -70,7 +70,7 @@ class mapgeo:
     def unload(self):
         """Remove o plugin do QGIS."""
         for action in self.actions:
-            self.iface.removePluginDatabaseMenu(self.tr(u'&Mapeamento Geológico'), action)
+            self.iface.removePluginMenu(self.tr(u'&Mapeamento Geológico'), action)
             self.iface.removeToolBarIcon(action)
 
     def run(self):


### PR DESCRIPTION
## Summary
- replace deprecated `addPluginToDatabaseMenu` and `removePluginDatabaseMenu`
- run plugin unit tests

## Testing
- `PYENV_VERSION=3.10.17 pytest -q fonte/mapgeo/test/test_init.py` *(fails: ModuleNotFoundError: No module named 'qgis')*
- `PYENV_VERSION=3.10.17 pytest -q` *(fails: ModuleNotFoundError: No module named 'qgis')*


------
https://chatgpt.com/codex/tasks/task_e_686c4c2ac594832dabfed3d854644798