### PR TITLE
Fix unary_union usage in utils

### DIFF
--- a/fonte/mapgeo/nucleo/utils.py
+++ b/fonte/mapgeo/nucleo/utils.py
@@ -2,6 +2,7 @@ import os
 import matplotlib.pyplot as plt
 import pygmt
 import geopandas as gpd
+from shapely.ops import unary_union
 
 
 # funções e variáveis úteis podem ser adicionadas aqui conforme necessário
@@ -46,7 +47,7 @@ def get_epsg(folha_id):
 # define geometria do Brasil
 ibge = set_db('shapefiles/IBGE/')
 regioes = gpd.read_file(ibge + 'ANMS2010_06_grandesregioes.shp')
-brasil = regioes.unary_union
+brasil = unary_union(regioes.geometry)
 
 
 meta_cartas = {


### PR DESCRIPTION
## Summary
- import unary_union helper from shapely
- compute Brasil outline using `unary_union(regioes.geometry)`

## Testing
- `./venv/bin/python -m pytest -q` *(fails: No module named 'qgis')*

------
https://chatgpt.com/codex/tasks/task_e_686c4c311770832d9ce3b4f6186ba5dd