### PR TITLE
Add database engine and plugin UI tests with CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Test
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest sqlalchemy geoalchemy2
+    - name: Run tests
+      run: |
+        pytest fonte/mapgeo/test/test_databaseengine.py fonte/mapgeo/test/test_plugin_ui.py

--- a/fonte/mapgeo/test/__init__.py
+++ b/fonte/mapgeo/test/__init__.py
@@ -1,2 +1,5 @@
 # import qgis libs so that ve set the correct sip api version
-import qgis   # pylint: disable=W0611  # NOQA
+try:  # noqa: SIM105 - simple try/except for optional dependency
+    import qgis  # pylint: disable=W0611
+except ImportError:  # pragma: no cover - optional dependency not present
+    pass

--- a/fonte/mapgeo/test/test_databaseengine.py
+++ b/fonte/mapgeo/test/test_databaseengine.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from mapgeo import databaseengine
+
+class DatabaseEngineTest(unittest.TestCase):
+    def setUp(self):
+        databaseengine.DatabaseEngine._instance = None
+
+    def test_engine_and_session_singleton(self):
+        fake_engine = MagicMock(name="engine")
+        fake_session = MagicMock(name="session")
+
+        sessionmaker_instance = MagicMock(return_value=fake_session)
+
+        with patch('mapgeo.databaseengine.create_engine', return_value=fake_engine) as ce, \
+             patch('mapgeo.databaseengine.sessionmaker', return_value=sessionmaker_instance) as sm, \
+             patch.object(databaseengine.Base.metadata, 'create_all') as create_all:
+            engine = databaseengine.DatabaseEngine.get_engine()
+            session = databaseengine.DatabaseEngine.get_session()
+
+        ce.assert_called_once_with(databaseengine.url)
+        create_all.assert_called_once_with(fake_engine)
+        sm.assert_called_once_with(bind=fake_engine)
+        sessionmaker_instance.assert_called_once_with()
+        self.assertIs(engine, fake_engine)
+        self.assertIs(session, fake_session)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/fonte/mapgeo/test/test_plugin_ui.py
+++ b/fonte/mapgeo/test/test_plugin_ui.py
@@ -1,0 +1,63 @@
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock
+
+# Create minimal qgis stubs so mapgeo can be imported without QGIS
+qgis_module = types.ModuleType('qgis')
+pyqt_module = types.ModuleType('qgis.PyQt')
+qtcore_module = types.ModuleType('qgis.PyQt.QtCore')
+qtcore_module.QSettings = MagicMock()
+qtcore_module.QTranslator = MagicMock()
+qtcore_module.QCoreApplication = MagicMock()
+qtgui_module = types.ModuleType('qgis.PyQt.QtGui')
+qtgui_module.QIcon = MagicMock()
+qtwidgets_module = types.ModuleType('qgis.PyQt.QtWidgets')
+qtwidgets_module.QAction = MagicMock()
+
+sys.modules.setdefault('qgis', qgis_module)
+sys.modules.setdefault('qgis.PyQt', pyqt_module)
+sys.modules.setdefault('qgis.PyQt.QtCore', qtcore_module)
+sys.modules.setdefault('qgis.PyQt.QtGui', qtgui_module)
+sys.modules.setdefault('qgis.PyQt.QtWidgets', qtwidgets_module)
+
+# Stub the dialog used by the plugin
+dialog_module = types.ModuleType('mapgeo.mapgeo_dialog')
+class DummyDialog:
+    def __init__(self, iface):
+        self.iface = iface
+        self.show = MagicMock()
+
+dialog_module.mapgeoDialog = DummyDialog
+sys.modules['mapgeo.mapgeo_dialog'] = dialog_module
+
+from mapgeo.mapgeo import mapgeo
+
+class DummyIface:
+    def addToolBarIcon(self, action):
+        pass
+    def removeToolBarIcon(self, action):
+        pass
+    def addPluginToDatabaseMenu(self, menu, action):
+        pass
+    def removePluginDatabaseMenu(self, menu, action):
+        pass
+    def mainWindow(self):
+        return None
+
+class PluginRunTest(unittest.TestCase):
+    def test_run_initializes_dialog_and_shows_it(self):
+        iface = DummyIface()
+        plugin = mapgeo(iface)
+        plugin.first_start = True
+        plugin.dlg = None
+        plugin.run()
+        self.assertIsNotNone(plugin.dlg)
+        plugin.dlg.show.assert_called_once()
+        # running again should reuse same dialog
+        plugin.dlg.show.reset_mock()
+        plugin.run()
+        plugin.dlg.show.assert_called_once()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle optional qgis import in tests package
- test DatabaseEngine initialization using mocks
- test plugin run action using PyQt/QGIS stubs
- run new tests in GitHub Actions

## Testing
- `pytest fonte/mapgeo/test/test_databaseengine.py fonte/mapgeo/test/test_plugin_ui.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686c4c3e85bc832db8d21211f7804602