### PR TITLE
Add future import for plugin uploader

### DIFF
--- a/fonte/mapgeo/plugin_upload.py
+++ b/fonte/mapgeo/plugin_upload.py
@@ -5,6 +5,8 @@
         git sha              : $TemplateVCSFormat
 """
 
+from future import standard_library
+
 import sys
 import getpass
 import xmlrpc.client


### PR DESCRIPTION
## Summary
- add missing `standard_library` import so plugin uploader can run

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686c5d3988a8832dbce3dd5c1f4267b4