### PR TITLE
Propagate STAC band metadata to outputs

### DIFF
--- a/codes/full_pipeline.py
+++ b/codes/full_pipeline.py
@@ -217,6 +217,7 @@ def build_datasets(
         X=X_pix,
         y=y_pix,
         bands=np.array(list(super_cube.band.values)),
+        band_metadata=np.array([super_cube.attrs.get("band_metadata", {})], dtype=object),
     )
     print(f"[OUTPUT] Dataset de pixels salvo em: {pixels_path}")
 
@@ -242,6 +243,7 @@ def build_datasets(
         bands=np.array(list(super_cube.band.values)),
         patch_size=np.array([patch_size]),
         stride=np.array([stride]),
+        band_metadata=np.array([super_cube.attrs.get("band_metadata", {})], dtype=object),
     )
     print(f"[OUTPUT] Dataset de patches salvo em: {patches_path}")
 

--- a/codes/gs_fusion.py
+++ b/codes/gs_fusion.py
@@ -133,10 +133,23 @@ def gs_fusion_aster_with_pan(
             "y": aster_ms.y,
             "x": aster_ms.x,
         },
-        attrs=aster_ms.attrs,
+        attrs={**aster_ms.attrs},
     )
     aster_fused.rio.write_crs(aster_ms.rio.crs, inplace=True)
     aster_fused.rio.write_transform(aster_ms.rio.transform(), inplace=True)
+    band_metadata = {**aster_ms.attrs.get("band_metadata", {})}
+    for band_name in aster_fused.band.values:
+        key = str(band_name)
+        meta = band_metadata.get(key, {}).copy()
+        meta.update(
+            {
+                "process": "Gram-Schmidt fusion (ASTER VNIR/SWIR upscaled using Sentinel-2 B08 as PAN)",
+                "reference_band": str(pan_da.band.values[0] if "band" in pan_da.coords else "B08"),
+            }
+        )
+        band_metadata[key] = meta
+    aster_fused.attrs["band_metadata"] = band_metadata
+    aster_fused.attrs.setdefault("long_name", list(aster_fused.band.values))
     aster_fused = sanitize_long_name(aster_fused)
     return aster_fused
 
@@ -161,7 +174,7 @@ def run_gs_pair_pipeline(
     s2_item = get_signed_item(s2_collection, s2_id)
     print(f"[GS PIPELINE] S2 item: {s2_item.id}")
 
-    s2_ref_da, s2_bands = load_s2_bands_for_folha(
+    s2_ref_da, s2_bands, _s2_meta = load_s2_bands_for_folha(
         item=s2_item,
         folha_geom=folha_geom,
         band_ids=s2_band_ids,
@@ -170,6 +183,7 @@ def run_gs_pair_pipeline(
 
     s2_stack_list = []
     s2_labels: List[str] = []
+    s2_band_metadata: Dict[str, Any] = {}
     for bname in s2_band_ids:
         da_b = s2_bands.get(bname)
         if da_b is None:
@@ -179,7 +193,10 @@ def run_gs_pair_pipeline(
         else:
             arr = da_b.values[0, :, :]
         s2_stack_list.append(arr)
-        s2_labels.append(bname)
+
+        band_label = str(da_b.band.values[0]) if "band" in da_b.coords else bname
+        s2_labels.append(band_label)
+        s2_band_metadata[band_label] = da_b.attrs.get("band_metadata", {}).get(band_label, {})
 
     s2_stack = xr.DataArray(
         data=np.stack(s2_stack_list, axis=0),
@@ -189,7 +206,11 @@ def run_gs_pair_pipeline(
             "y": s2_ref_da.y,
             "x": s2_ref_da.x,
         },
-        attrs={"description": "Sentinel-2 bands recortadas"},
+        attrs={
+            "description": "Sentinel-2 bands recortadas",
+            "band_metadata": s2_band_metadata,
+            "source_item": s2_item.id,
+        },
     )
     s2_stack.rio.write_crs(s2_ref_da.rio.crs, inplace=True)
     s2_stack.rio.write_transform(s2_ref_da.rio.transform(), inplace=True)

--- a/codes/raster_utils.py
+++ b/codes/raster_utils.py
@@ -106,12 +106,56 @@ def sanitize_long_name(da: xr.DataArray) -> xr.DataArray:
     return da
 
 
+def _extract_stac_band_metadata(asset: Any) -> List[Dict[str, Any]]:
+    extra = getattr(asset, "extra_fields", {}) or {}
+    for key in ("eo:bands", "raster:bands", "bands"):
+        bands = extra.get(key)
+        if isinstance(bands, list):
+            return [band if isinstance(band, dict) else {} for band in bands]
+    return []
+
+
+def _build_band_labels(
+    asset: Any,
+    prefix: str,
+    n_bands: int,
+    fallback_ids: Optional[List[str]] = None,
+) -> Tuple[List[str], Dict[str, Dict[str, Any]]]:
+    stac_bands = _extract_stac_band_metadata(asset)
+    labels: List[str] = []
+    metadata: Dict[str, Dict[str, Any]] = {}
+
+    for idx in range(n_bands):
+        band_meta = stac_bands[idx] if idx < len(stac_bands) else {}
+        default_name = fallback_ids[idx] if fallback_ids and idx < len(fallback_ids) else f"{idx + 1}"
+
+        name = str(band_meta.get("name") or default_name)
+        common_name = band_meta.get("common_name")
+        label_parts = [prefix, name]
+        if common_name and str(common_name).lower() != name.lower():
+            label_parts.append(str(common_name))
+        label = "_".join(label_parts)
+
+        labels.append(label)
+        metadata[label] = {
+            "asset": getattr(asset, "title", None) or getattr(asset, "href", None),
+            "band_index": idx,
+            "band_id": default_name,
+            "common_name": common_name,
+            "center_wavelength": band_meta.get("center_wavelength"),
+            "full_width_half_max": band_meta.get("full_width_half_max"),
+            "description": band_meta.get("description") or getattr(asset, "description", None),
+        }
+
+    return labels, metadata
+
+
 def load_s2_bands_for_folha(
     item: Any,
     folha_geom: Dict[str, Any],
     band_ids: List[str],
     cache_dir: Optional[str] = None,
-) -> Tuple[xr.DataArray, Dict[str, xr.DataArray]]:
+) -> Tuple[xr.DataArray, Dict[str, xr.DataArray], Dict[str, Dict[str, Any]]]:
     assets = item.assets
     if "B02" not in assets:
         raise RuntimeError("Asset B02 não encontrado no item Sentinel-2.")
@@ -120,6 +164,7 @@ def load_s2_bands_for_folha(
     ref_da = clip_raster_to_folha(ref_href, folha_geom, cache_dir=cache_dir)
 
     s2_bands: Dict[str, xr.DataArray] = {}
+    s2_band_metadata: Dict[str, Dict[str, Any]] = {}
     for bname in band_ids:
         asset = assets.get(bname)
         if asset is None:
@@ -127,9 +172,21 @@ def load_s2_bands_for_folha(
             continue
         da_b = clip_raster_to_folha(asset.href, folha_geom, cache_dir=cache_dir)
         da_b = da_b.rio.reproject_match(ref_da)
-        s2_bands[bname] = da_b
 
-    return ref_da, s2_bands
+        band_labels, band_meta = _build_band_labels(
+            asset=asset,
+            prefix="S2",
+            n_bands=da_b.sizes.get("band", 1),
+            fallback_ids=[bname] * da_b.sizes.get("band", 1),
+        )
+        da_b = da_b.assign_coords(band=("band", band_labels))
+        da_b.attrs.setdefault("long_name", band_labels)
+        da_b.attrs["band_metadata"] = band_meta
+
+        s2_bands[bname] = da_b
+        s2_band_metadata.update(band_meta)
+
+    return ref_da, s2_bands, s2_band_metadata
 
 
 def load_aster_vnir_swir_for_folha(
@@ -144,8 +201,11 @@ def load_aster_vnir_swir_for_folha(
     if "SWIR" not in assets:
         raise RuntimeError("Asset 'SWIR' não encontrado no item ASTER.")
 
-    da_vnir = clip_raster_to_folha(assets["VNIR"].href, folha_geom, cache_dir=cache_dir)
-    da_swir = clip_raster_to_folha(assets["SWIR"].href, folha_geom, cache_dir=cache_dir)
+    vnir_asset = assets["VNIR"]
+    swir_asset = assets["SWIR"]
+
+    da_vnir = clip_raster_to_folha(vnir_asset.href, folha_geom, cache_dir=cache_dir)
+    da_swir = clip_raster_to_folha(swir_asset.href, folha_geom, cache_dir=cache_dir)
 
     da_vnir_match = da_vnir.rio.reproject_match(s2_ref_da)
     da_swir_match = da_swir.rio.reproject_match(s2_ref_da)
@@ -154,11 +214,22 @@ def load_aster_vnir_swir_for_folha(
 
     nb_vnir = da_vnir_match.sizes["band"]
     nb_swir = da_swir_match.sizes["band"]
-    band_names = (
-        [f"VNIR_{i+1}" for i in range(nb_vnir)] +
-        [f"SWIR_{i+4}" for i in range(nb_swir)]
+    vnir_labels, vnir_meta = _build_band_labels(
+        asset=vnir_asset,
+        prefix="ASTER_VNIR",
+        n_bands=nb_vnir,
     )
+    swir_labels, swir_meta = _build_band_labels(
+        asset=swir_asset,
+        prefix="ASTER_SWIR",
+        n_bands=nb_swir,
+        fallback_ids=[str(i + 4) for i in range(nb_swir)],
+    )
+    band_names = vnir_labels + swir_labels
+    band_metadata = {**vnir_meta, **swir_meta}
     aster_all = aster_all.assign_coords(band=("band", band_names))
+    aster_all.attrs.setdefault("long_name", band_names)
+    aster_all.attrs["band_metadata"] = band_metadata
     aster_all = sanitize_long_name(aster_all)
     return aster_all
 

--- a/codes/supercube.py
+++ b/codes/supercube.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from typing import Optional
 
@@ -27,6 +28,12 @@ def build_supercube(
 
     super_cube = xr.concat([s2_stack, aster_gs], dim="band")
     super_cube = super_cube.assign_coords(band=("band", super_names))
+    super_meta = {
+        **s2_stack.attrs.get("band_metadata", {}),
+        **aster_gs.attrs.get("band_metadata", {}),
+    }
+    super_cube.attrs["band_metadata"] = super_meta
+    super_cube.attrs.setdefault("long_name", super_names)
     super_cube.rio.write_crs(s2_stack.rio.crs, inplace=True)
     super_cube.rio.write_transform(s2_stack.rio.transform(), inplace=True)
 
@@ -42,6 +49,21 @@ def build_supercube(
     )
     os.makedirs(os.path.dirname(out), exist_ok=True)
     super_cube.rio.to_raster(out)
+    meta_path = f"{out}.meta.json"
+    with open(meta_path, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "band_names": super_names,
+                "band_metadata": super_meta,
+                "sources": {
+                    "s2_stack_path": s2_stack_path,
+                    "aster_gs_path": aster_gs_path,
+                },
+            },
+            f,
+            indent=2,
+            ensure_ascii=False,
+        )
     print(f"[SUPERCUBE] Super-cubo salvo em: {out}")
     return super_cube
 
@@ -56,4 +78,15 @@ def load_supercube(
         f"{folha_codigo}_S2_ASTER_GS_supercube_10m.tif",
     )
     da = rioxarray.open_rasterio(path, masked=True).astype("float32")
+
+    meta_path = f"{path}.meta.json"
+    if os.path.exists(meta_path):
+        with open(meta_path, "r", encoding="utf-8") as f:
+            meta = json.load(f)
+        band_names = meta.get("band_names")
+        if band_names and len(band_names) == da.sizes.get("band", len(band_names)):
+            da = da.assign_coords(band=("band", band_names))
+        if "band_metadata" in meta:
+            da.attrs["band_metadata"] = meta["band_metadata"]
+    da = sanitize_long_name(da)
     return da


### PR DESCRIPTION
## Summary
- derive band names from STAC metadata for Sentinel-2 and ASTER inputs and carry them into fused outputs
- embed detailed band metadata into GS fusion results, supercube artifacts, and saved datasets
- persist supercube band metadata alongside raster outputs for later reuse

## Testing
- python -m compileall codes *(fails: pyenv could not find requested `geologia` environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927550861a0832d8a57d6147b7f8716)