### PR TITLE
Add start/end log timestamps and duration output

### DIFF
--- a/codes/log_utils.py
+++ b/codes/log_utils.py
@@ -22,7 +22,8 @@ class Tee:
 @contextlib.contextmanager
 def log_stdout(log_dir: str, base_name: str):
     os.makedirs(log_dir, exist_ok=True)
-    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    start_time = datetime.datetime.now()
+    ts = start_time.strftime("%Y%m%d_%H%M%S")
     log_path = os.path.join(log_dir, f"{base_name}_{ts}.log")
 
     f = open(log_path, "w")
@@ -33,7 +34,19 @@ def log_stdout(log_dir: str, base_name: str):
 
     try:
         print(f"[LOG] Registrando execução em: {log_path}")
+        print(
+            f"[LOG] Início: {start_time.isoformat(sep=' ', timespec='seconds')}"
+        )
         yield log_path
     finally:
+        end_time = datetime.datetime.now()
+        duration = end_time - start_time
+        duration_seconds = duration.total_seconds()
+        duration_minutes = duration_seconds / 60
+        print(f"[LOG] Término: {end_time.isoformat(sep=' ', timespec='seconds')}")
+        print(
+            f"[LOG] Duração total: {duration_seconds:.2f} segundos "
+            f"({duration_minutes:.2f} minutos)"
+        )
         sys.stdout, sys.stderr = old_out, old_err
         f.close()


### PR DESCRIPTION
## Summary
- capture log start time before redirecting stdout/stderr
- print start header and end/duration details to both stdout and log file

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927934abcfc832dade12bfef3d84a11)